### PR TITLE
2-froglike6

### DIFF
--- a/froglike6/README.md
+++ b/froglike6/README.md
@@ -3,4 +3,5 @@
  | 차시 |    날짜    | 문제유형 | 링크 | 풀이 |
  |:----:|:---------:|:----:|:-----:|:----:|
  | 1차시 | 2025.03.18 |  자료 구조  | [괄호](https://www.acmicpc.net/problem/9012)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/1|
+ | 2차시 | 2025.03.20 |  정수  | [공약수](https://www.acmicpc.net/problem/1792)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/6|
  ---

--- a/froglike6/number_theory/1792.cpp
+++ b/froglike6/number_theory/1792.cpp
@@ -1,0 +1,62 @@
+#include <bits/stdc++.h>
+#define ll long long
+#define MAX 50001
+
+using namespace std;
+
+ll mu[MAX] = {0, 1}; 
+unordered_map<int, ll> mp;
+
+ll sum_mu(int x) {
+   int j;
+   if (x<MAX) return mu[x];
+   if (mp.find(x) != mp.end()) return mp[x];
+   ll ret = 1;
+   for (int i=2; i<=x; i=j+1) {
+      j = x/(x/i);
+      ret -= (j-i+1) * sum_mu(x/i);
+   }
+   return mp[x] = ret;
+}
+
+void init_mu(){
+    for (int i=1; i<MAX; i++) {
+      for (int j=2; j*i<MAX; j++) mu[j*i] -= mu[i];
+      mu[i] += mu[i-1];
+   }
+}
+
+ll count_coprime_pairs(int a, int b){
+    ll result=0;
+    ll q_a, q_b, r, mu_sum;
+    ll i = 1, n = min(a,b);
+    while (i<=n){
+        q_a = a/i;
+        q_b = b/i;
+        r = min(a/q_a, b/q_b);
+        mu_sum = sum_mu(r) - sum_mu(i-1);
+        result += (q_a * q_b) * mu_sum;
+        i=r+1;
+    }
+    return result;
+}
+
+void solve(int a, int b, int d){
+    cout << count_coprime_pairs(a/d, b/d) << "\n";
+}
+
+int main()
+{
+   //freopen("./input.txt", "r", stdin);
+   ios::sync_with_stdio(false);
+   cin.tie(NULL);
+   init_mu();
+   int a,b,d,n;
+   cin >> n;
+   for (int i=0;i<n;i++){
+       cin >> a >> b >> d;
+       solve(a,b,d);
+   }
+   
+   return 0;
+}


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
[공약수](https://www.acmicpc.net/problem/1792)

## ✔️ 소요된 시간
문제 분석만 2시간. 관련 코드를 작년부터 계속 공부하는 중이었어서, 그 시간을 빼면 전체 걸린 시간은 6시간 정도.

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
Pypy3으로 돌려도 시간초과 나길래 C++로 바꿨어요 ㅠㅠ
<details><summary>수도 코드</summary>
<p>

```
전역 변수 선언:
  - 뫼비우스 함수 값을 저장할 배열 mu 초기화 (mu[1] = 1)
  - 뫼비우스 함수의 합을 메모이제이션할 해시맵 mp 선언

함수 sum_mu(x):
  만약 x가 미리 계산된 범위 내에 있다면, mu[x] 반환
  만약 x에 대한 값이 mp에 저장되어 있다면, mp[x] 반환

  결과값 ret을 1로 초기화
  i를 2부터 x까지 반복:
    j를 x를 (x를 i로 나눈 몫)으로 나눈 결과로 설정
    ret에서 (j - i + 1) * sum_mu(x / i) 값을 뺌
  계산된 ret 값을 mp[x]에 저장하고 반환

함수 init_mu():
  i를 1부터 최대 범위까지 반복:
    j를 2부터 시작하여 j * i가 최대 범위보다 작을 때까지 반복:
      mu[j * i]에서 mu[i] 값을 뺌
    현재 mu[i] 값에 이전 값 mu[i - 1]을 더함

함수 count_coprime_pairs(a, b):
  결과값 result를 0으로 초기화
  i를 1부터 min(a, b)까지 반복:
    a를 i로 나눈 몫을 q_a에 저장
    b를 i로 나눈 몫을 q_b에 저장
    r을 min(a / q_a, b / q_b)로 설정
    mu_sum을 sum_mu(r) - sum_mu(i - 1)로 계산
    result에 (q_a * q_b) * mu_sum 값을 더함
    i를 r + 1로 갱신
  result 반환

함수 solve(a, b, d):
  count_coprime_pairs(a / d, b / d) 결과를 출력

main 함수:
  입출력 최적화 설정
  init_mu() 호출하여 뫼비우스 함수 초기화
  테스트 케이스 개수 n 입력받음
  n번 반복하면서:
    a, b, d 입력받음
    solve(a, b, d) 호출
  프로그램 종료
```

</p>
</details> 

이 문제는 세 개의 정수 $a$, $b$, $d$를 주면 다음과 같은 조건을 만족하는 자연수 순서쌍 $(x, y)$의 개수를 구하라는 문제입니다.
$$1\le x \le a,   1\le y \le b,   \rm gcd\it(x, y) = d$$

일단 $x$와 $y$부터 보면, 두 수의 최대공약수가 $d$이므로 임의의 자연수인 $x'$, $y'$에 대해 $x=d \bullet x'$, $y=d \bullet y'$로 치환할 수 있습니다. 그렇게 된다면 문제의 조건이 다음과 같이 바뀌게 됩니다.
$$1\le x' \le \frac{a}{d},   1\le y' \le \frac{b}{d},   \rm gcd\it(x', y') = 1$$

이를 통해서 1부터 $\frac{a}{d}$와 $\frac{b}{d}$ 사이에서 서로소(gcd가 1이므로)인 $(x', y')$의 개수를 찾으면 된다는 것을 알았습니다. 일단 문제는 여기까지 두고, 풀이를 위한 공식과 함수를 보겠습니다.

> [!CAUTION]
>  여기에서 수학적 증명은 코드 짜는데 필요도 없고, 수준이 너무 높아서 저도 잘 못하기 때문에 필요한 경우가 아니라면 계속 생략하겠습니다. 

> [!NOTE]
> 어떤 정수 $a$와 $b$가 있습니다. $a$를 $b$의 약수라고 한다면, $b$를 $a$의 배수라고도 할 수 있습니다. 정수론을 다룰 때, 이런 경우는 $a \mid b$라고 표시하고, 약수가 아닌 경우에는 $a \nmid b$라고 표시합니다.
> 대괄호 안의 수식이 만족하는 경우, 1로 취급하고 그렇지 않은 경우에는 0으로 취급합니다. 예를 들어, $[2+1=3]=1$이고 $[2-1=3]=0$입니다.

### 뫼비우스 함수
뫼비우스 함수 $\mu(n)$은 어떤 수 $n$의 소인수분해로부터 시작합니다. 소인수분해를 했을 때 나오는 수들을 약수라고 합니다. 이 약수 중에서 하나라도 제곱수(4, 9, 16, 25...)가 있다면 $\mu(n)=0$입니다. 

그리고 약수 중에서 제곱수가 없을 때에는 소인수의 개수를 살펴보아야 합니다. 소인수의 개수가 짝수이면 $\mu(n)=1$이고, 홀수이면 $\mu(n)=-1$입니다. 

### 뫼비우스 반전 공식
어떤 함수 $f$와 $g$가 있습니다. 이 두 함수는 자연수 $n$에 대해 다음 관계가 성립한다고 가정해봅시다.
$$g(n)=\displaystyle\sum_{d \mid n} f(d)$$

그렇다면 다음과 같이 $f$와 $g$의 위치를 바꾸어도 성립하게 되고, 이를 뫼비우스 반전 공식이라고 합니다("반전"이라고 부르는 이유는 $n$과 $d$의 위치가 바뀌어서 이고, 반전된 결과에 뫼비우스 함수가 있어서 "뫼비우스" 반전 공식이라고 합니다.).
$$f(n)=\displaystyle\sum_{d \mid n} g(d) \mu(\frac{n}{d})$$

### 문제 풀이
다시 문제 풀이로 돌아오겠습니다. 앞서 설명했던 문제를 다음과 같이 나타낼 수 있습니다.
$$\displaystyle\sum_{x'=1}^{\lfloor\frac{a}{d}\rfloor} \sum_{y'=1}^{\lfloor\frac{b}{d}\rfloor} [(\rm gcd\it (x', y')=1]$$

이 때, $[(\rm gcd\it (x', y')=1]$에 뫼비우스 반전 공식을 적용하여 수정하면 다음과 같습니다(사실 이 부분의 수학적인 증명은 이해못했어요 ㅠㅠ).
$$\displaystyle\sum_{k=1}^{\rm min\it(\lfloor\frac{a}{d}\rfloor, \lfloor\frac{b}{d}\rfloor)} \mu(k) \lfloor\frac{a}{kd}\rfloor \lfloor\frac{b}{kd}\rfloor$$

여기서 floor 부분은 구간을 나누어서 쉽게 합하면 되고, 뫼비우스 함수의 부분합이 문제가 됩니다. 그냥 구해서 더하면 시간초과가 납니다(약 $\mathcal{O}(N\log(N))$ ). 그래서 뫼비우스 함수의 부분합을 빠르게 구하는 방법이 필요합니다.

### 메르텐스 함수
메르텐스 함수 $M(n)$은 다음과 같이 정의됩니다.
$$M(n)=\displaystyle\sum_{k=1}^{n}\mu(k)$$
우리가 필요한 뫼비우스 함수의 부분합이 바로 이 메르텐스 함수입니다. 초기값이 1이 아니어도 시그마의 성질에 의해 쉽게 구할 수 있습니다. 이 메르텐스 함수를 $\mathcal{O}(N^{2/3})$만에 구하는 방법을 알아보겠습니다.

### Xudyh's Sieve
Xudyh's Sieve는 메르텐스 함수를 특정한 전처리를 통해 $\mathcal{O}(N^{2/3})$만에 구하는 방법입니다. 이 방법을 이해하려고 했지만 너무 어려워서, 코드 구현만 하게 되었습니다..

최종적으로 이 모든 것을 종합해서 문제를 해결할 수 있었습니다.
설명이 빈약한 것 같은데 궁금하신 점 있다면 Comment로 남겨주세요! 최대한 답변드리겠습니다.

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
[Mertens Trick(Xudyh's Sieve)](https://xy-plane.tistory.com/19)
[뫼비우스 반전 공식](https://codeforces.com/blog/entry/53925)
뫼비우스 함수의 부분합을 빠르게 구하는 방법인 Xudyh's Sieve에 대해서는 알고 있었지만, 실제로 구현해본 것은 처음입니다.
문제에서 주어진 $[(\rm gcd\it (x', y')=1]$에 뫼비우스 반전 공식을 적용하는데, 이 부분에 대해 알게 되었습니다.