### PR TITLE
6-froglike6

### DIFF
--- a/froglike6/README.md
+++ b/froglike6/README.md
@@ -7,4 +7,5 @@
  | 3차시 | 2025.03.24 |  정수  | [피보나치 수와 최대공약수](https://www.acmicpc.net/problem/11778)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/9|
  | 4차시 | 2025.03.30 | 그래프 | [친구](https://www.acmicpc.net/problem/1058)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/16|
  | 5차시 | 2025.04.01 |  정수  | [개구리](https://www.acmicpc.net/problem/25333)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/17|
+ | 6차시 | 2025.04.07 | 백트래킹| [N-Queen](https://www.acmicpc.net/problem/9663)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/24|
  ---

--- a/froglike6/backtracking/9663.py
+++ b/froglike6/backtracking/9663.py
@@ -1,0 +1,17 @@
+def dfs(row, cols, diag1, diag2):
+    global count
+    if row == n:
+        count += 1
+        return
+    available_positions = (~(cols | diag1 | diag2)) & ((1 << n) - 1)
+    while available_positions:
+        position = available_positions & -available_positions
+        available_positions &= available_positions - 1
+        dfs(row + 1,
+            cols | position,
+            (diag1 | position) << 1,
+            (diag2 | position) >> 1)
+n = int(input())
+count = 0
+dfs(0, 0, 0, 0)
+print(count)


### PR DESCRIPTION
## 🔗 문제 링크  
<!-- 해결한 문제의 링크를 올려주세요. -->  
[N-Queen](https://www.acmicpc.net/problem/9663)  

## ✔️ 소요된 시간  
약 40분  

## ✨ 수도 코드  
서로 공격하지 않는 N개의 퀸을 N×N 체스판 위에 놓을 수 있는 모든 경우의 수를 구하는 문제입니다.

퀸은 **같은 행, 같은 열, 같은 대각선**에 있는 말을 공격할 수 있으므로, 다음 제약을 만족하는지 확인하며 탐색합니다.

<details><summary>수도코드</summary>
<p>

```
1. 입력으로 n(체스판 크기)를 받는다.

2. 백트래킹 함수 dfs(row, cols, diag1, diag2)를 정의한다.
   - row: 현재 탐색 중인 행 번호
   - cols: 이미 퀸이 놓인 열 정보 (비트마스크)
   - diag1: "/" 방향 대각선 정보 (왼쪽 위 → 오른쪽 아래)
   - diag2: "\" 방향 대각선 정보 (오른쪽 위 → 왼쪽 아래)

3. dfs에서 다음을 수행한다.
   - row가 n이면 퀸을 모두 배치한 경우이므로 해 개수를 +1 한다.
   - 가능한 위치를 비트 연산으로 구한다.
     available = ~(cols | diag1 | diag2) & ((1 << n) - 1)
   - 가능한 모든 위치에 대해:
     - 하나의 위치 p를 선택 (가장 오른쪽 비트)
     - 해당 위치를 마스크에서 제거
     - 재귀 호출: 다음 행으로 이동하고, cols, diag1, diag2를 갱신하여 전달한다.

4. 결과값을 출력한다.
```

</p>
</details>

![ezgif-4ec8fb9c3774e9](https://github.com/user-attachments/assets/7e364687-df08-48b9-97a3-9b4c2a9be4da)



저는 **비트마스크**를 이용한 백트래킹 방식으로 해결했습니다.  
예전에 어느 어려운 문제(아마도 루비 문제)에서 봤던 기억이 나서 사용해보았습니다.
이 방법은 열/대각선 제약 조건을 **비트 연산**으로 빠르게 검사할 수 있어 매우 효율적입니다.


###  비트마스크

비트마스크는 정수의 이진수 표현을 활용하여 여러 개의 상태를 하나의 숫자로 표현하는 기법입니다.  
각 비트는 특정 조건의 충족 여부를 의미하며, 1이면 참(True), 0이면 거짓(False)을 나타냅니다.

#### 예시

체스판이 n = 4일 때,  
숫자 `0b1010` (이진수)은 다음과 같은 상태를 뜻합니다:

- 0번 열: 없음 (0)
- 1번 열: 있음 (1)
- 2번 열: 없음 (0)
- 3번 열: 있음 (1)

즉, 퀸이 1번과 3번 열에 있다는 뜻입니다.

---
#### 코드 설명
- `cols`: 특정 열에 퀸이 이미 배치되었는지 여부
- `diag1`: ↘ 방향 대각선 (row + col이 같은 위치)
- `diag2`: ↙ 방향 대각선 (row - col이 같은 위치)

비트 연산을 통해 충돌 여부를 O(1)로 판단할 수 있습니다.

```python
available = ~(cols | diag1 | diag2) & ((1 << n) - 1)
```

이 코드는 "현재 행에서 퀸을 놓을 수 있는 위치"를 계산합니다.  
한 줄씩 쉽게 설명해보면:

1. `cols | diag1 | diag2`

   지금까지 퀸이 놓인 열, ↘ 방향 대각선, ↙ 방향 대각선 정보를 모두 합칩니다.  
   - `|` 연산은 "또는"이므로, 어느 한 곳이라도 퀸이 있으면 1이 됩니다.

2. `~(cols | diag1 | diag2)`

   위에서 1이 된 부분(퀸이 있거나 공격받는 자리)을 반전시켜  
   → 퀸을 **놓을 수 있는 자리만 1**로 만듭니다.

3. `& ((1 << n) - 1)`

   예: n = 4라면 `1 << 4 = 16 = 0b10000`  
   `((1 << n) - 1)` → `0b1111` (하위 n비트만 1)  
   이것을 `&` 연산해서 **n x n 체스판 이외의 상위 비트를 제거**합니다.

이 계산의 결과인 `available`은  
**현재 행에서 퀸을 놓을 수 있는 열을 1로 표시한 비트마스크**입니다.

---
#### 다음 코드

```python
position = available & -available
```

- 현재 가능한 자리 중에서 **가장 오른쪽에 있는 1비트 하나만 추출**합니다.
- 예: `available = 0b10100` → `position = 0b00100`

```python
available &= available - 1
```

- 방금 선택한 자리(position)를 available에서 제거합니다.
- 다음 반복에서는 **나머지 가능한 자리들만 탐색**하게 됩니다.

### 백트래킹

백트래킹은 가능한 해를 찾기 위해 모든 후보를 탐색하되, 유효하지 않은 경우 더 깊은 탐색을 하지 않고 즉시 되돌아가는 탐색 기법입니다.

이 문제에서는 다음과 같은 조건에서 백트래킹이 적용됩니다:
- 현재 위치에 퀸을 놓았을 때, 열/대각선 중 하나라도 이미 사용 중이면 **즉시 가지치기**
- 그렇지 않으면 재귀적으로 다음 행에 대해 반복
- 퀸을 N개 전부 배치하면 해의 수를 증가시킴

## 📚 새롭게 알게된 내용

- **비트 연산**을 활용하면 열, 대각선 충돌 여부를 매우 빠르게 판단할 수 있어 성능이 크게 향상됨
- `x & -x`를 이용해 **가장 오른쪽 1비트**를 빠르게 추출할 수 있음 (대표적인 비트마스크 트릭)
- 백트래킹에 비트마스크를 결합하면 효율성과 단순성을 동시에 얻을 수 있음
- OEIS A000170 수열을 통해 N-Queens 문제의 해 개수를 사전에 참고할 수 있음

> 참고: [OEIS A000170](https://oeis.org/A000170)

