### PR TITLE
7-froglike6

### DIFF
--- a/froglike6/README.md
+++ b/froglike6/README.md
@@ -8,4 +8,5 @@
  | 4차시 | 2025.03.30 | 그래프 | [친구](https://www.acmicpc.net/problem/1058)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/16|
  | 5차시 | 2025.04.01 |  정수  | [개구리](https://www.acmicpc.net/problem/25333)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/17|
  | 6차시 | 2025.04.07 | 백트래킹| [N-Queen](https://www.acmicpc.net/problem/9663)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/24|
+ | 7차시 | 2025.04.09 | 그래프 | [최소비용 구하기](https://www.acmicpc.net/problem/1916)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/27|
  ---

--- a/froglike6/graph_theory/1916.py
+++ b/froglike6/graph_theory/1916.py
@@ -1,0 +1,30 @@
+import sys
+import heapq
+
+def dijkstra(n, graph, start):
+    INF = float('inf')
+    distances = [INF] * (n + 1)
+    distances[start] = 0
+    queue = [(0, start)]
+    
+    while queue:
+        current_cost, current_node = heapq.heappop(queue)
+        if current_cost > distances[current_node]:
+            continue
+        for next_node, weight in graph[current_node]:
+            cost = current_cost + weight
+            if cost < distances[next_node]:
+                distances[next_node] = cost
+                heapq.heappush(queue, (cost, next_node))
+    return distances
+
+input = sys.stdin.readline
+N = int(input())
+M = int(input())
+graph = [[] for _ in range(N+1)]
+for _ in range(M):
+    u, v, w = map(int, input().split())
+    graph[u].append((v, w))
+start, end = map(int, input().split())
+distances = dijkstra(N, graph, start)
+print(distances[end])


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
[최소비용 구하기](https://www.acmicpc.net/problem/1916)

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
1시간

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->

<details><summary>수도코드</summary>
<p>

```
함수 다익스트라(노드개수 n, 그래프, 시작노드 start):
    무한대(INF)를 정의한다.
    모든 노드에 대한 최단 거리 배열 distances를 INF로 초기화 (인덱스 0부터 n까지)
    distances[start] = 0  // 시작노드의 거리는 0으로 설정
    우선순위 큐(queue)에 (0, start) 튜플을 넣는다.

    큐가 빌 때까지 반복:
        큐에서 (현재비용, 현재노드)를 꺼낸다.
        만약 현재비용이 이미 저장된 distances[현재노드]보다 크다면, 이미 더 좋은 경로가 있으므로 이번 반복 건너뛴다.
        현재노드의 이웃 노드들을 순회:
            (다음노드, 가중치) 각각에 대하여:
                누적비용 = 현재비용 + 가중치
                만약 누적비용이 distances[다음노드]보다 작다면:
                    distances[다음노드] = 누적비용 (더 나은 경로 발견!)
                    큐에 (누적비용, 다음노드)를 추가한다.
    함수 종료 후, distances 배열을 반환한다.

메인 실행 부분:
    표준 입력으로부터 노드의 개수 N을 입력 받는다.
    간선(경로)의 개수 M을 입력 받는다.
    노드1부터 노드N까지의 인접 리스트 형태의 그래프를 초기화한다.

    M번 반복:
        각 줄로부터 u, v, w를 입력 받는다. (u에서 v로 가는 경로의 가중치 w)
        그래프[u] 리스트에 (v, w)를 추가한다.

    시작 노드와 도착 노드를 입력 받는다.
    다익스트라 함수를 호출하여 시작 노드로부터 도착 노드까지 최단 경로를 구한다.
    도착 노드의 최단 경로 값을 출력한다.
``` 

</p>
</details> 

이 문제는 다익스트라의 정석 같은 문제입니다. 다익스트라 알고리즘은 먼저 모든 간선의 가중치를 무한대로 두고 시작합니다. 그런 다음 모든 노드를 탐색하며 어떤 노드에서 다른 노드로 갈 때의 최소 가중치를 저장합니다. 이렇게 모든 노드를 탐색 완료하면 특정 노드에서 다른 특정 노드로 갈 때의 최소 가중치를 알 수 있게 됩니다. 
![dijkstra](https://github.com/user-attachments/assets/342d2e1c-b05b-4fc3-8d11-d4442fb1c9f6)

문제에서 출발점과 도착점이 나와있기 때문에, 도시들과 버스 비용을 노드와 가중치로 삼아 다익스트라 알고리즘을 사용합니다. 그렇게 해서 나온 최소 가중치가 버스가 이동할 때의 최소비용이 되게 됩니다.

설명을 적긴 적었는데 부족해보이네요..ㅠㅠ 혹시나 모르는 부분 있으면 comment 달아주세요 ㅎㅎ

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
