### PR TITLE
14-hadongun

### DIFF
--- a/hadongun/README.md
+++ b/hadongun/README.md
@@ -14,5 +14,6 @@
  | 10차시| 2025.05.07 |  수학  | [통계학](https://www.acmicpc.net/problem/2108)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/36|
  | 11차시| 2025.05.09 |  다이나믹 프로그래밍  | [2xn 타일링](https://www.acmicpc.net/problem/11726)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/44|
  | 12차시| 2025.05.13 |  스택  | [탑](https://www.acmicpc.net/problem/2493)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/48|
- | 13차시| 2025.05.15 |  스택  | [오큰수] (https://www.acmicpc.net/problem/17298)||
+ | 13차시| 2025.05.15 |  스택  | [오큰수] (https://www.acmicpc.net/problem/17298)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/50|
+ | 14차시| 2025.05.20 |  트리  | [트리의 부모 찾기] (https://www.acmicpc.net/problem/11725)||
  ---

--- a/hadongun/트리/트리의 부모 찾기.py
+++ b/hadongun/트리/트리의 부모 찾기.py
@@ -1,0 +1,46 @@
+import sys
+input = sys.stdin.readline
+
+def bfs(root, n, graph):
+    parent = [0]*n
+    visited = [False]*n
+    stack = []
+    
+    visited[root-1] = True
+    
+    for neighbor in graph[root]:
+        stack.append(neighbor)
+        parent[neighbor-1] = root
+        visited[neighbor-1] = True
+        
+    while stack:
+        temp = stack.pop()
+        for neighbor in graph[temp]:
+            if not visited[neighbor-1]:
+                parent[neighbor-1] = temp
+                visited[neighbor-1] = True
+                stack.append(neighbor)
+    return parent
+n = int(input())
+
+graph = [[] for _ in range(n+1)]
+
+for _ in range(n-1):
+    a,b = map(int, input().split())
+    graph[a].append(b)
+    graph[b].append(a)
+root = 1
+result = bfs(root, n, graph)
+count = 0
+for i in result:
+    if count == 0:
+        count += 1
+        continue
+    else:
+        print(i)
+    count += 1
+    
+    
+    
+
+


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
https://www.acmicpc.net/problem/11725

## ✔️ 소요된 시간
1h

## ✨ 수도 코드
저번에 현석님이 푸셨던 트리 관련 문제를 가져와봤습니다.

트리를 제대로 구현해 본 적이 없어서 그런지 코드가 좀 난잡한 것 같기도 하네요

우선 인접 리스트를 이용해 입력 값들을 저장했습니다.

![image](https://github.com/user-attachments/assets/75d639fd-f020-4a8c-a561-a27dac78a58c)
입력이 위와 같이 한 줄마다 2개의 정점이 주어지기 때문에 이 두 정점을 변수 a,b 에 넣고 
변수 이름이 graph인 리스트를 만들어 graph[a] 에 b값을, graph[b]에 a값을 넣어
아래의 사진처럼 저장했습니다
![image](https://github.com/user-attachments/assets/183caad6-339a-4182-a307-bed8d356c234)

하지만 이렇게 저장하면 어떤 놈이 부모이고 어떤 놈이 자식인지 모르기 때문에
이를 구별하기 위해 dfs를 사용했습니다. (구현할 때는 bfs로 하려고 해서 함수 명을 bfs로 했는데, 이제 보니 dfs네요..^<^)


우선 방문을 완료 했는지 알기 위한 visited 리스트, index 값에 해당하는 노드의 부모 노드를 저장하기 위한 parent 리스트, 그리고 stack을 선언했습니다. 위 리스트를 선언할 때 크기를 n으로 하였는데, 노드는 1부터 시작해서 index 값에 변수를 사용할 때는 -1을 해주었습니다.
(크기를 n+1로 선언하는 게 더 좋은 것 같네요). root는 시작이므로 방문 처리하였습니다.

제가 생각하기에 이제부터 중요한 부분인데
1. 루트와 인접해있는 정점들을 하나씩 꺼내 stack에 넣습니다.(아직 stack이 비어있기 때문에)
2. 여기서 꺼낸 정점들의 부모는 현재 인접해있는 root가 되기 때문에 **parent[정점-1]** 에 root를 넣어줍니다.
3. 이후 **visited[정점-1]** 을 방문 처리해줍니다.


이후 while문으로 stack이 빌 때까지 반복하도록 합니다.
부모의 노드 값을 저장하기 위해 **temp = stack.pop()** 

-> 방문 처리한 정점은 부모를 알게 되었으므로 더 이상 볼 필요가 없습니다
따라서 아직 방문하지 않은 정점인 경우
parent[neighbor-1] = temp -> 부모 노드 저장
visited[neighbor-1] = True -> 방문 처리
stack.append(neighbor) -> 정점을 스택에 넣음
-> 스택에 방문 처리한 neighbor을 넣는 이유가 뭐냐? 함은
실제로 스택에서 꺼낸 값을 그대로 쓰는 건 temp에 할당하는 부모로 사용되고 실제로는 스택에서 꺼낸 값과 연결된 정점들을 꺼내 쓰기 위함입니다..

![리수뜨](https://github.com/user-attachments/assets/7c463c2a-b2bd-4c26-804f-619d42084671)
요런 느낌?

이후 parent를 리턴하고 0인덱스를 제외한 값들을 print해줍니답..


<details><summary>Details</summary>
<p>

```python
입력 받기:
    - 노드 개수 N을 입력 받음
    - N+1 크기의 빈 인접 리스트 graph 생성
    - N-1개의 간선을 입력 받아 양방향으로 graph에 저장

루트 노드를 기준으로 트리를 탐색하기 위해:
    - 크기 N의 부모 배열 parent 생성
    - 크기 N의 방문 배열 visited 생성
    - 빈 스택 stack 생성

    - 루트 노드를 방문 처리
    - 루트의 모든 이웃 노드를 순회하면서:
        - 방문 처리
        - 부모 기록
        - 스택에 추가

스택을 이용해 DFS 방식으로 트리 탐색 시작:
    - 스택이 빌 때까지 반복:
        - 현재 노드를 스택에서 꺼냄
        - 현재 노드의 이웃 노드들을 순회:
            - 아직 방문하지 않은 노드라면:
                - 부모를 현재 노드로 기록
                - 방문 처리
                - 스택에 추가

모든 노드에 대한 부모 정보를 구했으므로:
    - parent 리스트에서 첫 번째 항목은 루트 자신이므로 생략하고
    - 2번 노드부터 N번 노드까지의 부모를 차례대로 출력

``` 

</p>
</details> 

## 📚 새롭게 알게된 내용
