### PR TITLE
16-1-froglike6

### DIFF
--- a/froglike6/README.md
+++ b/froglike6/README.md
@@ -18,4 +18,5 @@
  | 14차시 | 2025.05.15 | 선형대수학 | [행렬 제곱](https://www.acmicpc.net/problem/10830)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/51|
  | 15차시 | 2025.05.21 | 구현 | [큐빙](https://www.acmicpc.net/problem/5373)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/57|
  | 16차시 | 2025.05.22 | 애드 혹 | [IZ*ONE Sequence](https://www.acmicpc.net/problem/33581)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/59|
+ | 16-1차시 | 2025.05.29 | 정수 | [N의 배수 (4)](https://www.acmicpc.net/problem/25448)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/63|
  ---

--- a/froglike6/number_theory/25448.cpp
+++ b/froglike6/number_theory/25448.cpp
@@ -1,0 +1,146 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+using i64 = long long;
+using u64 = unsigned long long;
+using u128 = __uint128_t;
+
+u64 pow_mod(u64 x, u64 y, u64 m){
+    u64 r = 1 % m;
+    x %= m;
+    while(y){
+        if(y & 1) r = (u128)r * x % m;
+        x = (u128)x * x % m;
+        y >>= 1;
+    }
+    return r;
+}
+
+bool mr_wit(u64 n, u64 a){
+    u64 d = n - 1, s = 0;
+    while(!(d & 1)){ d >>= 1; ++s; }
+    u64 x = pow_mod(a, d, n);
+    if(x == 1 || x == n - 1) return false;
+    for(u64 i = 1; i < s; ++i){
+        x = (u128)x * x % n;
+        if(x == n - 1) return false;
+    }
+    return true;
+}
+
+bool is_prime(u64 n){
+    if(n < 2) return false;
+    int small[]{2,3,5,7,11,13,17,19,23,29,31,37};
+    for(int p: small) if(n % p == 0) return n == (u64)p;
+    u64 bases[]{2,325,9375,28178,450775,9780504,1795265022};
+    for(u64 a: bases) if(a % n && mr_wit(n, a % n)) return false;
+    return true;
+}
+
+i64 find_t(i64 p, const vector<char>& T, i64 d, i64 u, i64 v, i64 inv){
+    i64 lo = (u128(u) * inv) % p;
+    i64 hi = p + (u128(v) * inv) % p;
+    while(lo + 1 != hi){
+        i64 mid = (lo + hi) >> 1;
+        if(T[(u128(mid) * d) % p]) lo = mid;
+        else hi = mid;
+    }
+    return (u128(hi) * d) % p;
+}
+
+vector<char> egz_prime(i64 p, const vector<i64>& a){
+    i64 m = 2 * p - 1;
+    vector<int> mods(m);
+    for(i64 i = 0; i < m; ++i) mods[i] = a[i] % p;
+    vector<int> k(m); iota(k.begin(), k.end(), 0);
+    sort(k.begin(), k.end(), [&](int x,int y){ return mods[x] < mods[y]; });
+    vector<char> L(m,0);
+    for(i64 i = 0; i < p - 1; ++i){
+        if(mods[k[1+i]] == mods[k[p+i]]){
+            for(i64 j = 1+i; j <= p+i; ++j) L[k[j]] = 1;
+            return L;
+        }
+    }
+    i64 s = 0; for(i64 i = 0; i < p; ++i) s += mods[k[i]];
+    s %= p;
+    vector<char> T(p,0); vector<i64> P(p,-1); T[s] = 1;
+    unordered_map<i64,i64> inv_cache;
+    for(i64 i = 1; i < p && !T[0]; ++i){
+        i64 d = mods[k[p+i-1]] - mods[k[i]];
+        if(d < 0) d += p;
+        i64 inv = inv_cache.count(d) ? inv_cache[d] : (inv_cache[d] = pow_mod(d, p-2, p));
+        i64 t = find_t(p,T,d,s,0,inv);
+        T[t]=1; P[t]=i;
+    }
+    i64 c = 0;
+    for(i64 i = 0; i < p; ++i) L[k[i]] = 1;
+    while(s != c){
+        int idx1 = k[p + P[c] - 1];
+        int idx2 = k[P[c]];
+        L[idx1] = 1; L[idx2] = 0;
+        c = (c - (mods[idx1] - mods[idx2])) % p;
+        if(c < 0) c += p;
+    }
+    return L;
+}
+
+vector<char> EGZ(i64, const vector<i64>&);
+
+vector<char> egz_comp(i64 p, i64 q, const vector<i64>& a){
+    vector<i64> sums;
+    vector<int> win;
+    for(i64 i=0;i<p-1;++i) win.push_back(i);
+    for(i64 i=0;i<2*q-1;++i){
+        for(i64 j=(i+1)*p-1;j<(i+2)*p-1;++j) win.push_back(j);
+        vector<i64> sub; sub.reserve(win.size());
+        for(int id:win) sub.push_back(a[id]);
+        auto flags = egz_prime(p,sub);
+        i64 s=0; vector<int> nxt; nxt.reserve(win.size());
+        for(size_t j=0;j<flags.size();++j)
+            if(flags[j]) s += a[win[j]];
+            else nxt.push_back(win[j]);
+        sums.push_back(s/p);
+        win.swap(nxt);
+    }
+    auto sel = EGZ(q,sums);
+    vector<char> L(2*p*q-1,0);
+    win.clear();
+    for(i64 i=0;i<p-1;++i) win.push_back(i);
+    for(i64 i=0;i<2*q-1;++i){
+        for(i64 j=(i+1)*p-1;j<(i+2)*p-1;++j) win.push_back(j);
+        vector<i64> sub; sub.reserve(win.size());
+        for(int id:win) sub.push_back(a[id]);
+        auto flags = egz_prime(p,sub);
+        if(sel[i])
+            for(size_t j=0;j<flags.size();++j) if(flags[j]) L[win[j]]=1;
+        vector<int> nxt; nxt.reserve(win.size());
+        for(size_t j=0;j<flags.size();++j) if(!flags[j]) nxt.push_back(win[j]);
+        win.swap(nxt);
+    }
+    return L;
+}
+
+vector<char> EGZ(i64 n, const vector<i64>& a){
+    if(n==1) return {1};
+    if(is_prime(n)) return egz_prime(n,a);
+    for(i64 d=2; d*d<=n; ++d)
+        if(n%d==0) return egz_comp(d,n/d,a);
+    return {};
+}
+
+int main(){
+    ios::sync_with_stdio(false);
+    cin.tie(nullptr);
+    i64 N; if(!(cin>>N)) return 0;
+    vector<i64> A(2*N-1);
+    for(auto& x:A) cin>>x;
+    auto mask = EGZ(N,A);
+    bool first=true;
+    for(i64 i=0;i<2*N-1;++i)
+        if(mask[i]){
+            if(!first) cout<<' ';
+            cout<<A[i]; first=false;
+        }
+    cout<<'\n';
+    return 0;
+}


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
[N의 배수 (4)](https://www.acmicpc.net/problem/25448)

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
처음 이 문제를 시도한게 1년 전입니다. 가끔 생각날 때 몇 시간 정도 생각하다보니 정확히 소요된 시간은 잘 모르겠네요 ㅠㅠ

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
설명 작성하는데 시간이 걸릴 것 같은데, N의 배수 시리즈 문제를 먼저 풀어보시는 것 추천합니다 ㅎㅎ
[N의 배수 (1)](https://www.acmicpc.net/problem/18790)

---
이 문제는 [EGZ 정리(제로-섬 문제)](https://en.wikipedia.org/wiki/Zero-sum_problem)와 관련이 깊은 문제입니다. 
EGZ 정리(Erdős–Ginzburg–Ziv Theorem)란, 정수 $n$에 대해 $2n-1$개의 아무 정수를 모아두면, 그 중 $n$개를 골라 합했을 때 $n$의 배수가 되는 부분집합이 반드시 존재한다는 정리입니다. 
문제에서는 `답을 만족하는 수들이 존재하지 않는 경우 -1을 출력하여라.`라고 했지만, `-1`이 되는 경우는 EGZ 정리에 따라 없습니다.

그래서 **반드시 존재**한다는 것은 확인했으나 **조건을 만족하는 수**는 어떻게 구해야 할까요?
바로 [이 논문](https://arxiv.org/abs/2208.07728)을 통해 문제를 풀 수 있었습니다. 기존에는 $\mathcal{O}(n^2)$ 방법 밖에 없었지만, 이 논문을 통해 $\mathcal{O}(n \log n)$만으로도 해결할 수 있었습니다.
자세한 증명은 어려우니 생략하고, 대략적으로 어떻게 작동하는지만 설명하겠습니다.

### 알고리즘

> **한 줄 요약** : 숫자를 두 번 잘 묶으면, 소수든 합성수든 금세 `n`개를 찾아낼 수 있다!

#### 1. 핵심 직관

1. **정렬** : 모든 숫자를 `mod n` 값 순으로 나열해 두면, 같은 나머지끼리 묶기 편합니다.
2. **작은 집합 확장** : 증명에서 쓰는 `S_i`(가능한 나머지 집합)를 한 단계씩 키우면, 결국 0이 포함됩니다.
3. **블록 재귀** : `n`이 합성수라면 두 소인수로 나누어 같은 작업을 두 번 하면 끝납니다.

> 복잡해 보여도, 구조는 "정렬 → 차이 계산 → 블록 묶기" 세 부분만 거치면 끝납니다.

#### 2. 소수 `p` 일 때 

| 단계                  | 하는 일                             | 왜 필요한가?                    |
| ------------------- | -------------------------------- | -------------------------- |
| ① **mod 정렬**        | \(b_1, b_2, …, b_{2p-1}\) 으로 정렬  | 같은 나머지가 두 번 나오면 바로 끝      |
| ② **간격 정의**  | `d_i = b_{i+p} − b_i` (mod p)    | 차이를 이용해 새로운 나머지를 만들기 위해    |
| ③ **집합 키우기** | `S_{i} = S_{i-1} ⊕ {0, d_{i-1}}` | 매 단계 크기 +1, 결국 크기 p → 0 포함 |
| ④ **0 포착**          | 0이 나오면 역추적                       | 고른 원소가 어떤 것인지 복원           |

- 구현 팁 : `S_i`를 통째로 들고 다닐 필요 없이, **배열 **``**(길이 i)** 만 저장하면 메모리는 O(p)입니다.
- `d_i`를 어느 쪽에서 가져올지 결정할 때는 **이분 탐색**으로 log p만에 선택 가능해서 전체가 O(p log p)가 됩니다.

#### 3. 합성수 `n = p q` 일 때

1. **q짜리 블록** 2p−1개 만들기   → 각 블록 합이 0 (mod q) (소수 q 버전 적용)
2. **블록 합을 다시 소수 p 버전**에 넣기   → p개 블록 골라서 합이 0 (mod p)
3. **두 조건 합치면**   → 전체 pq개 원소, 합 0 (mod pq) 완성

> 소인수 분해를 따라 재귀적으로 돌리면 어떤 `n`도 해결 가능합니다.

---

따라서 이 알고리즘을 구현하면, 바로 이 문제를 풀 수 있습니다. 


## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
이 내용 전부가 다 새롭게 알게 된 내용이었습니다....