### PR TITLE
17-hadongun

### DIFF
--- a/hadongun/README.md
+++ b/hadongun/README.md
@@ -17,5 +17,6 @@
  | 13차시| 2025.05.15 |  스택  | [오큰수] (https://www.acmicpc.net/problem/17298)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/50|
  | 14차시| 2025.05.20 |  트리  | [트리의 부모 찾기] (https://www.acmicpc.net/problem/11725)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/56|
  | 15차시| 2025.05.21 |  트리  | [트리] (https://www.acmicpc.net/problem/1068)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/58|
- | 16차시| 2025.06.27 |  구현  | [킹] (https://www.acmicpc.net/problem/1063)||
+ | 16차시| 2025.06.27 |  구현  | [킹] (https://www.acmicpc.net/problem/1063)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/68|
+ | 17차시| 2025.07.04 |  두 포인터  | [두 수의 합] (https://www.acmicpc.net/problem/3273)||
  ---

--- a/hadongun/두 포인터/두 수의 합.py
+++ b/hadongun/두 포인터/두 수의 합.py
@@ -1,0 +1,28 @@
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+arr = list(map(int, input().split()))
+x = int(input())
+
+arr.sort()
+start = 0
+end = n-1
+Sum = 0
+count = 0
+while start < end:
+    Sum = arr[start] + arr[end]
+    if Sum == x:
+        count += 1
+        start += 1
+        end -= 1
+        
+    elif Sum < x:
+        start += 1
+        
+    else:
+        end -= 1
+print(count)
+
+        
+        


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
[두 수의 합](https://www.acmicpc.net/problem/3273)

## ✔️ 소요된 시간
45m

## ✨ 수도 코드
다른 골드 문제를 도전하다 두 포인터를 알게 되어 공부하고자 이 문제를 가져오게 되었습니다. 

이번 문제와 같이 합이 x인 수열의 쌍을 찾아야 하는 문제의 경우, 
일반적인 선형 탐색으로 한다면 최악의 경우 시간 복잡도가 o(n^2)으로 배열이 길다면 매우 오래 걸리게 되는 불상사가 발생합니다.
하지만 두 포인터를 사용한다면 o(n)만에 해결할 수 있더군요!!

![image](https://github.com/user-attachments/assets/8b8db467-b09a-4678-b4ef-68288359128a)

우선 정렬된 배열의 상태로 시작합니다.
start 포인터를 배열의 제일 첫 인덱스, end 포인터를 배열의 제일 마지막 인덱스로 지정합니다. (여기서 포인터는 그냥 인덱스 값을 가리키는 변수로 생각하였습니다)

이후 Sum =  arr[start] + arr[end] 하여 Sum 값과 x값을 비교합니다.
1. Sum < x 인 경우
  목표하는 x 값보다 Sum 값이 작은 경우에는 더해주는 값을 늘려줘야 하기 때문에 start 포인터 값을 1 증가시킵니다. ( 배열은 오름차순 정렬이 되어있으므로)
2. Sum > x 인 경우
목표하는 값보다 Sum 값이 크기 때문에 end 포인터 값을  1 감소시킵니다. (인덱스가 작아지면 Sum에 더해지는 값도 작아짐 -> x값에 가까워짐)
3. Sum == x 인 경우
목표 값을 찾았으므로 count로 세어줍니다.
이후 start 는 1을 더해주고, end는 1을 빼줍니다. 

**why??** 만약 start 값이 3인 경우 start 값이 0, 1, 2, 3 일 때의 경우는 모두 확인하였기 때문에 다음 값으로 넘어감
start 값이 증가하면 더해주는 값이 증가 -> 현재 end 값이 유지되면 목표치인 x 값보다 Sum이 커지므로 end 포인터 값을 1 감소시켜요


<details><summary>수도코드</summary>
<p>

```python
입력: 정수 n
입력: 정수 n개로 이루어진 리스트 arr
입력: 목표 정수 x

arr를 오름차순 정렬

start ← 0
end ← n - 1
count ← 0

반복 (start < end):
    Sum ← arr[start] + arr[end]
    
    만약 Sum == x 이면:
        count를 1 증가
        start를 1 증가
        end를 1 감소

    그렇지 않고 Sum < x 이면:
        start를 1 증가

    그렇지 않으면:  // Sum > x
        end를 1 감소

count 출력

``` 

</p>
</details> 

  



## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
