### PR TITLE
19-fnhid

### DIFF
--- a/fnhid/Graph/17352.cpp
+++ b/fnhid/Graph/17352.cpp
@@ -1,0 +1,48 @@
+#include <iostream>
+#include <vector>
+#include <stack>
+
+using namespace std;
+using Graph = vector<vector<int> >;
+
+void dfs(Graph &graph, vector<bool> &visited) {
+    stack<int> s;
+    s.push(1);
+    visited[1] = true;
+    while (!s.empty()) {
+        int v = s.top();
+        s.pop();
+        for (int neigh: graph[v]) {
+            if (!visited[neigh]) {
+                visited[neigh] = true;
+                s.push(neigh);
+            }
+        }
+    }
+}
+
+int main() {
+    int n;
+    cin >> n;
+    Graph G(n + 1);
+    vector<bool> visited(n + 1, false);
+    for (int i = 0; i < n - 2; i++) {
+        int a, b;
+        cin >> a >> b;
+        G[a].push_back(b);
+        G[b].push_back(a);
+    } // set graph
+
+    dfs(G, visited);
+
+    int iso = -1;
+    for (int i = 2; i < n + 1; i++) {
+        if (!visited[i]) {
+            iso = i;
+            break;
+        }
+    }
+
+    cout << 1 << " " << iso;
+    return 0;
+}

--- a/fnhid/Queue/3190.cpp
+++ b/fnhid/Queue/3190.cpp
@@ -1,0 +1,91 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+enum WORDS {
+    VOID,
+    APPLE,
+    BODY
+};
+
+#define X first
+#define Y second
+
+int dx[4] = {0, 1, 0, -1};
+int dy[4] = {1, 0, -1, 0};
+
+int solve(int n, vector<pair<int, char> > &cmd, vector<vector<int> > &board) {
+    int time = 0, length = 1, dir_idx = 0, cmd_idx = 0;
+
+
+    pair<int, int> head = {0, 0}, tail;
+    queue<pair<int, int> > q;
+
+    q.push({0, 0});
+    board[0][0] = BODY;
+
+    while (true) {
+        time++;
+        //move
+        head.X += dx[dir_idx];
+        head.Y += dy[dir_idx];
+
+        // crash check
+        if (head.X < 0 || head.Y < 0 || head.X >= n || head.Y >= n ||
+            board[head.X][head.Y] == BODY)
+            break;
+
+        if (board[head.X][head.Y] != APPLE) {
+            tail = q.front();
+            q.pop();
+            board[tail.first][tail.second] = VOID;
+        }
+        q.push(head);
+        board[head.X][head.Y] = BODY;
+
+
+        // dir change for next time
+        if (cmd_idx < cmd.size() && cmd[cmd_idx].first == time) {
+            if (cmd[cmd_idx].second == 'D') {
+                dir_idx = (dir_idx + 1) % 4;
+            } else {
+                // 'L'
+                dir_idx = (dir_idx + 3) % 4; // 3 mod 4 == -1 mod 4
+            }
+            cmd_idx++;
+        }
+    }
+    return time;
+}
+
+
+int main() {
+    cin.tie(nullptr)->sync_with_stdio(false);
+    int n, k;
+    cin >> n >> k;
+
+    vector<vector<int> > board(n, vector<int>(n, 0)); // 1: apple, 2: body
+    board[0][0] = BODY;
+
+    pair<int, int> apl; // first: row, second: column
+
+
+    for (int i = 0; i < k; i++) {
+        cin >> apl.first >> apl.second;
+
+        apl.first--;
+        apl.second--;
+        board[apl.first][apl.second] = APPLE;
+    }
+
+    int l;
+    cin >> l;
+
+    vector<pair<int, char> > cmd(l, {0, 0}); // first: time, second: dir idx
+    for (int i = 0; i < l; i++) {
+        cin >> cmd[i].first >> cmd[i].second;
+    }
+
+    cout << solve(n, cmd, board);
+    return 0;
+}
+

--- a/fnhid/String/1786.cpp
+++ b/fnhid/String/1786.cpp
@@ -1,0 +1,55 @@
+#include <vector>
+#include <iostream>
+
+using namespace std;
+
+vector<int> getPi(string &pattern) {
+    int m = pattern.size();
+    vector<int> pi(m, 0);
+    int j = 0;
+
+
+    for (int i = 1; i < m; ++i) {
+        while (j > 0 && pattern[i] != pattern[j]) j = pi[j - 1];
+        if (pattern[i] == pattern[j]) {
+            j++;
+            pi[i] = j;
+        }
+    }
+    return pi;
+}
+
+vector<int> kmp(string &pattern, string &text) {
+    vector<int> res;
+    vector<int> pi = getPi(pattern);
+    int j = 0;
+    int n = text.size(), m = pattern.size();
+    for (int i = 0; i < n; ++i) {
+        while (j > 0 && text[i] != pattern[j]) j = pi[j - 1];
+        if (text[i] == pattern[j]) {
+            if (j == m - 1) {
+                // success
+                res.push_back(i - m + 1);
+                j = pi[j];
+            } else {
+                j++;
+            }
+        }
+    }
+    return res;
+}
+
+int main() {
+    cin.tie(nullptr)->sync_with_stdio(false);
+    string P, T;
+    getline(cin, T);
+    getline(cin, P);
+    vector<int> res = kmp(P, T);
+    cout << res.size() << "\n";
+    for (int i: res) {
+        cout << i + 1 << " ";
+    }
+
+
+    return 0;
+}


### PR DESCRIPTION
## 🔗 문제 링크
[뱀](https://www.acmicpc.net/problem/3190)

## ✔️ 소요된 시간
30분

## ✨ 수도 코드
자료구조 중 큐를 연습해 볼 수 있는 구현 문제를 가져왔습니다.

![image](https://github.com/user-attachments/assets/e601a6bd-201c-4ad3-8dbc-a8c12a8e68a8)
이 문제는 뱀 게임에서, 사과의 위치와 방향 전환 정보(회전 시점, 회전 방향)를 제공하면, 몇 초만에 게임이 끝나는지 알아내는 문제입니다.

뱀은 1초에 한 칸 움직이고, 명령어 정보에 따라 회전합니다.

뱀이 몸통, 벽에 부딫히면 게임이 끝납니다.


2차원 배열로 게임 판의 정보(빈 공간, 사과, 몸통)를 저장하였고, 

c++의 STL인 queue를 이용하여 뱀의 위치 정보를 저장하였습니다.

뱀의 머리가 새로 이동하면, 그 부분의 좌표를 큐에 push하고, 
사과를 먹지 않았다면 길이가 유지되어야 하기 때문에 꼬리였던 부분의 좌표를 pop하였습니다.


<details><summary>수도 코드</summary>
<p>

```
함수 main
    N, K 입력
    N x N 크기 보드 생성

    K번 반복:
        사과 좌표 r, c 입력
        보드[r-1][c-1]에 사과 표시

    L 입력
    명령어 목록 생성
    L번 반복:
        시간, 방향 문자 입력
        명령어 목록에 {시간, 방향 문자} 저장

    결과 = solve(N, 명령어 목록, 보드)
    결과 출력

함수 solve(N, 명령어 목록, 보드)
    시간 = 0
    방향 = 0
    명령어_순번 = 0

    머리_좌표 = {0, 0}
    몸통_큐 생성, {0, 0} 추가
    보드[0][0]에 몸통 표시

    무한 반복:
        시간 1 증가
        머리_좌표를 현재 방향으로 이동

        만약 머리가 벽 또는 자기 몸에 닿으면:
            반복 중단

        만약 이동한 칸에 사과가 없으면:
            꼬리_좌표 = 몸통_큐의 맨 앞
            몸통_큐에서 제거
            보드에서 꼬리_좌표를 빈 칸으로

        몸통_큐에 새 머리_좌표 추가
        보드에서 새 머리_좌표를 몸통으로

        만약 현재 시간에 실행할 명령어가 있으면:
            만약 명령이 'D'이면, 방향을 오른쪽으로
            아니면, 방향을 왼쪽으로
            명령어_순번 1 증가

    시간 반환
```

</p>
</details> 

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
