### PR TITLE
20-Fnhid

### DIFF
--- a/fnhid/PriorityQueue/1374.cpp
+++ b/fnhid/PriorityQueue/1374.cpp
@@ -1,0 +1,48 @@
+#include <iostream>
+#include <queue>
+#include <vector>
+#include <algorithm>
+
+struct Lecture
+{
+    long long start, end;
+};
+
+int max(int a, int b)
+{
+    return a > b ? a : b;
+}
+
+using namespace std;
+
+int main()
+{
+    int n, id, answer=0;
+    priority_queue<long long, vector<long long>, greater<long long>> pq;
+
+
+    cin >> n;
+    vector<Lecture> v(n);
+    for (int i=0;i<n;i++)
+    {
+        cin >> id >> v[id-1].start >> v[id-1].end;
+    }
+
+    sort(v.begin(), v.end(), [](const Lecture& a, const Lecture& b)
+    {
+        return a.start < b.start;
+    });
+
+    for (Lecture& l : v)
+    {
+
+        while (!pq.empty() && pq.top() <= l.start)
+            pq.pop();
+        pq.push(l.end);
+        answer = max(answer, (int)pq.size());
+    }
+
+
+    cout << answer;
+
+}


### PR DESCRIPTION
## 🔗 문제 링크
[강의실](https://www.acmicpc.net/problem/1374)

## ✔️ 소요된 시간
할 만 해 보였지만 이런 문제가 익숙하지 않아서 그런지
아이디어를 떠올리기가 쉽지 않네요,,

40분 쯤에 구글링으로 힌트를 얻어 총 1시간 소요하여 해결했습니다.

문제 아이디어를 잘못 생각해서 삽질을 오래 했습니다


<img width="300" height="250" alt="image" src="https://github.com/user-attachments/assets/f57e4eb2-45ca-49be-8bab-7b63a6150315" />
ㅠㅠ

## ✨ 수도 코드
강의의 개수가 주어지고,
각 강의의 인덱스, 시작 시간, 종료 시간이 주어집니다.

이 때 강의를 겹치지 않게 강의실을 배정하려면 최소 몇 개의 강의실을 배정해야 하는지 알아내는 문제입니다.

먼저 강의를 시작 시간이 빠른 순으로 정렬합니다.
<img width="460" height="239" alt="image" src="https://github.com/user-attachments/assets/ecc7df7c-7fdc-4145-a147-c887999c479e" />


#### **우선순위 큐**
> 우선순위 큐에서 각 원소는 **우선순위**를 가지는데,
> 우선순위가 높은 원소가 먼저 처리됩니다.
> 보통 힙으로 구현합니다.
> 이 문제의 경우, 우선순위 큐에서 '가장 빨리 비는 강의실'를 먼저 빼야 하기 때문에 
> 강의들의 종료 시간을 우선순위 큐로 관리하고,
> 종료 시간이 빠른 강의를 우선순위를 높게 둡니다. (종료 시간을 기준으로 최소 힙을 사용합니다.)

<img width="607" height="548" alt="image" src="https://github.com/user-attachments/assets/2add3d8b-a61e-4dd2-aab8-301f770314b5" />

정렬된 순서대로 강의를 우선순위 큐에 삽입하는데, (삽입할 강의를 L, 우선순위 큐의 top에 있는 강의를 T라 하겠습니다) 

이 때 만약 T의 종료 시간이 L의 시작 시간과 같거나 앞에 있으면, 같은 강의실을 사용할 수 있으므로 top을 pop해 줍니다.

이후 L의 종료 시간을 새로 push합니다.
 
이를 반복하면, 강의가 들어올 때 마다 필요한 강의실의 수를 알 수 있습니다.

바로 우선순위 큐의 원소의 개수입니다.

따라서, 우선순위 큐의 원소의 개수의 최댓값을 구하면 문제를 해결할 수 있습니다.

## 📚 새롭게 알게된 내용
우선순위 큐같은 자료구조는 배웠는데도 아직 활용하기 어렵네요.. 더 많이 풀어보면서 익숙해져 보겠습니다.