### PR TITLE
21-hadongun

### DIFF
--- a/hadongun/README.md
+++ b/hadongun/README.md
@@ -21,5 +21,7 @@
  | 17차시| 2025.07.04 |  두 포인터  | [두 수의 합] (https://www.acmicpc.net/problem/3273)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/71|
  | 18차시| 2025.07.08 |  그래프 탐색  | [헌내기는 친구가 필요해] (https://www.acmicpc.net/problem/21736)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/75|
  | 19차시| 2025.07.11 |  문자열  | [IOIOI] (https://www.acmicpc.net/problem/5525)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/79|
- | 20차시| 2025.07.15 |  집합과 맵  | [비밀번호 찾기] (https://www.acmicpc.net/problem/17219)||
+ | 20차시| 2025.07.15 |  집합과 맵  | [비밀번호 찾기] (https://www.acmicpc.net/problem/17219)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/84|
+ | 21차시| 2025.07.16 |  집합과 맵  | [생태학] (https://www.acmicpc.net/problem/4358)||
+ 
  ---

--- a/hadongun/README.md
+++ b/hadongun/README.md
@@ -20,5 +20,6 @@
  | 16차시| 2025.06.27 |  구현  | [킹] (https://www.acmicpc.net/problem/1063)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/68|
  | 17차시| 2025.07.04 |  두 포인터  | [두 수의 합] (https://www.acmicpc.net/problem/3273)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/71|
  | 18차시| 2025.07.08 |  그래프 탐색  | [헌내기는 친구가 필요해] (https://www.acmicpc.net/problem/21736)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/75|
- | 19차시| 2025.07.11 |  문자열  | [IOIOI] (https://www.acmicpc.net/problem/5525)||
+ | 19차시| 2025.07.11 |  문자열  | [IOIOI] (https://www.acmicpc.net/problem/5525)|https://github.com/AlgoLeadMe/AlgoLeadMe-13/pull/79|
+ | 20차시| 2025.07.15 |  집합과 맵  | [비밀번호 찾기] (https://www.acmicpc.net/problem/17219)||
  ---

--- a/hadongun/집합과 맵/비밀번호 찾기.py
+++ b/hadongun/집합과 맵/비밀번호 찾기.py
@@ -1,0 +1,12 @@
+import sys
+
+n, m = map(int, input().split())
+
+passwords = {}
+for _ in range(n):
+    site, password = input().split()
+    passwords[site] = password
+
+for _ in range(m):
+    find = input().strip()
+    print(passwords[find])

--- a/hadongun/집합과 맵/생태학.py
+++ b/hadongun/집합과 맵/생태학.py
@@ -1,0 +1,21 @@
+import sys
+input = sys.stdin.readline
+
+tree = {}
+count = 0
+
+while True:
+    name = input().strip()
+    if name == '':
+        break
+    count += 1
+    if name in tree:
+        tree[name] += 1
+    else:
+        tree[name] = 1
+
+for name in tree:
+    tree[name] = round(tree[name] / count * 100, 4)
+
+for name in sorted(tree):
+    print(f"{name} {tree[name]:.4f}")


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
[생태학](https://www.acmicpc.net/problem/4358)

## ✔️ 소요된 시간
1h

## ✨ 수도 코드

이전 차시에서 했던 집합과 맵을 이용한 문제를 하나 더 가져왔습니다.

<img width="1107" height="1016" alt="image" src="https://github.com/user-attachments/assets/4856c321-8a72-4a72-b423-2d09f8014e0c" />

입력에서 나무의 종이 주어지는데, 이 수를 세어서 각 종이 차지하는 비율을 출력하는 문제입니다.

우선 입력 값의 수가 주어지지 않기 때문에 비어있는 입력이 나올 때까지 반복문으로 입력을 받아주었습니다.

파이썬 집합에서는 빈 값인 경우에 `+= 1` 사용이 안 되더라구요
그래서 if문으로 처음 입력 받는 종이면 `=1`, 이미 존재한다면 `+= 1` 을 사용하여 입력을 받아주었습니다!>
(입력 받을 때마다 count로 전체 수를 세어주었습니다)

모두 카운트 하였다면 각 종의 value 값에 count를 나누고 100을 곱해 백분율 값을 value값에 덮어씌웠습니다.

출력 조건에 맞게 정렬 후 f-string으로 소수 넷째 자리까지 출력하였습니당.

<details><summary>수도코드</summary>
<p>

```python
입력 스트림에서 나무 이름들을 한 줄씩 입력받음
(입력이 빈 줄이면 종료)

딕셔너리 tree를 초기화
전체 나무 수를 세는 변수 count를 0으로 초기화

반복:
    나무 이름을 한 줄 입력받고 공백 제거
    입력이 빈 문자열이면 반복 종료
    전체 개수 count를 1 증가
    만약 이름이 tree에 이미 있다면:
        tree[name] += 1
    아니면:
        tree[name] = 1  ← 처음 등장

모든 나무 이름에 대해:
    등장 횟수를 전체 개수로 나누고 * 100 해서 백분율로 변환
    소수점 4자리까지 반올림하여 덮어씌움

나무 이름들을 알파벳 순으로 정렬해서:
    각각의 이름과 백분율을 출력
    (출력 형식: "이름 비율(소수점 네 자리)")

``` 

</p>
</details> 


## 📚 새롭게 알게된 내용
f-string(gpt)